### PR TITLE
Fix YAML Language Detection on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# YAML files should be included in language statistics
+*.yaml linguist-detectable=true
+*.yml linguist-detectable=true
+
+# Mark generated files as generated to exclude them from statistics
+*.generated.yaml linguist-generated=true


### PR DESCRIPTION
Add .gitattributes file to ensure YAML files are properly detected and included in GitHub's language statistics. Generated YAML files are marked as generated to exclude them from the statistics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)