### PR TITLE
wip: add terraform action

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,39 @@
+name: Terraform
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  check:
+    name: Terraform Check
+    runs-on: ubuntu-latest
+    if: failure()
+    steps: [{ run: exit 1 }]
+    needs:
+      - changes
+
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: dorny/paths-filter@v3.0.2
+        id: filter
+        with:
+          filters: |
+            dev:
+              - aqua.yaml
+              - .terraform-version
+              - .github/actions/setup-tools/action.yaml
+              - .github/workflows/terraform.yaml
+              - terraform/modules/**
+              - terraform/env/dev/**


### PR DESCRIPTION
供養

戦略
- PR 上で plan を生成し artifact に (ロックがないので refresh しない)
- Merge Queue の並列数を1に制限した上で apply を実行する
- apply に成功したら main ブランチにマージ、そうでなければ plan を再計算して PR に戻す

懸念
- シークレット管理
    - plan のためには state の読み取り権限が必要だが、公開リポジトリでこれは難しい
- 管理コスト
    - それなりに複雑なワークフローが必要になる