### PR TITLE
Configure Renovate for GitHub Release References

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,18 @@
   "prConcurrentLimit": 10,
   "minimumReleaseAge": "3 days",
   "platformAutomerge": true,
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "regexManagers": [
+    {
+      "description": "Update raw.githubusercontent.com URLs in kustomization.yaml files",
+      "fileMatch": [
+        "(^|/)kustomization\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/(?<currentValue>[^/]+)/.*"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ]
 }


### PR DESCRIPTION
Configure Renovate to automatically track and update GitHub releases referenced via raw.githubusercontent.com URLs in kustomization.yaml files.

This enables automatic dependency updates for resources like Gateway API CRDs (currently at kubernetes-sigs/gateway-api v1.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)