### PR TITLE
Allow push metrics to k0s-pushgateway from k0s

### DIFF
--- a/ansible/roles/k0s/files/k0s-pushgateway-network-policy.yaml
+++ b/ansible/roles/k0s/files/k0s-pushgateway-network-policy.yaml
@@ -1,0 +1,28 @@
+# Network Policies for k0s-managed pushgateway
+# FYI: https://docs.k0sproject.io/stable/system-monitoring/
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: k0s-pushgateway
+  namespace: k0s-system
+  labels:
+    app: k0s-observability
+    component: pushgateway
+spec:
+  endpointSelector:
+    matchLabels:
+      app: k0s-observability
+      component: pushgateway
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP
+          rules:
+            http:
+              - method: POST
+                path: /metrics/.+
+    #TODO(#24): Scraper からの GET /metrics を許可する

--- a/ansible/roles/k0s/tasks/main.yaml
+++ b/ansible/roles/k0s/tasks/main.yaml
@@ -80,3 +80,18 @@
     mode: "0644"
     owner: root
     group: root
+
+- name: Create k0s manifests directory for metrics
+  ansible.builtin.file:
+    path: /var/lib/k0s/manifests/metrics
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+- name: Deploy pushgateway network policy
+  ansible.builtin.copy:
+    src: k0s-pushgateway-network-policy.yaml
+    dest: /var/lib/k0s/manifests/metrics/k0s-pushgateway-network-policy.yaml
+    mode: "0644"
+    owner: root
+    group: root


### PR DESCRIPTION
k0s は自らのメトリクスを Kubelet の Port Forwarding API を使って Pushgateway に送信する。
これを許可しないと etcd などのメトリクスが取得できない。

Kubelet からの通信は Pod と同じかどうかによって Cilium により`host`または`remote-node`の Entity が付与される。また Pushgateway はメトリクスの送信と取得でサービスを分けていないので L7 Policy を用いて送信のみを許可する。